### PR TITLE
fix multipart example partsize

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Multipart Upload archive
 
 Available since 0.0.8.
 
-    java -jar glacieruploader.jar --endpoint https://glacier.eu-west-1.amazonaws.com --vault myvaultname --multipartupload /path/to/my/file.zip --partsize 10485760
+    java -jar glacieruploader.jar --endpoint https://glacier.eu-west-1.amazonaws.com --vault myvaultname --multipartupload /path/to/my/file.zip --partsize 8388608
     
     Multipart uploading upload file.zip...
     Using endpoint https://glacier.eu-west-1.amazonaws.com


### PR DESCRIPTION
The partsize value 10485760 results in an error: `AWS Error Code: InvalidParameterValueException, AWS Error Message: Invalid part size: 10485760. Part size must not be null, must be a power of two and be between 1048576 and 4294967296 bytes.`.

Per https://forums.aws.amazon.com/message.jspa?messageID=482320, change it to 8388608